### PR TITLE
Fix: integer argument expected, got float

### DIFF
--- a/danmaku2ass.py
+++ b/danmaku2ass.py
@@ -627,7 +627,7 @@ def TestFreeRows(rows, c, row, width, height, bottomReserved, lifetime):
 
 def FindAlternativeRow(rows, c, height, bottomReserved):
     res = 0
-    for row in xrange(height-bottomReserved-math.ceil(c[7])):
+    for row in xrange(height-bottomReserved-int(math.ceil(c[7]))):
         if not rows[c[4]][row]:
             return row
         elif rows[c[4]][row][0] < rows[c[4]][res][0]:


### PR DESCRIPTION
It appears that Biligrab cannot deal with it with a `pass` in its function.

So here I come:

```
ERROR:root:'tuple' object has no attribute 'startswith'
INFO: Converting danmaku to ASS file with danmaku2ass(py2)...
INFO: Trying to get resolution...
INFO: Resolution is 1280x720
ERROR: Danmaku2ASS failed: integer argument expected, got float
       Head to https://github.com/m13253/danmaku2ass/issues to complain about this.
Traceback (most recent call last):
  File "b2.py", line 573, in convert_ass_py2
    font_size = int(math.ceil(resolution[1] / 21.6)), text_opacity= 1, comment_duration=8.0)
  File "/Users/Beining/Movies/danmaku2ass2.py", line 781, in Danmaku2ASS
    ProcessComments(comments, fo, stage_width, stage_height, reserve_blank, font_face, font_size, text_opacity, comment_duration, is_reduce_comments, progress_callback)
  File "/Users/Beining/Movies/danmaku2ass2.py", line 583, in ProcessComments
    row = FindAlternativeRow(rows, i, height, bottomReserved)
  File "/Users/Beining/Movies/danmaku2ass2.py", line 630, in FindAlternativeRow
    for row in xrange(height-bottomReserved-math.ceil(c[7])):
TypeError: integer argument expected, got float
```

Noticeable, on L640:

```
        for i in xrange(row, row+int(math.ceil(c[7]))):
```

There already existed a `int()`.

This fix will be pushed in the latest version of Biligrab. Works well for me.
