### PR TITLE
Fix the ReadCommentsAcfun method

### DIFF
--- a/danmaku2ass.py
+++ b/danmaku2ass.py
@@ -150,6 +150,8 @@ def ReadCommentsNiconico(f, fontsize):
 
 def ReadCommentsAcfun(f, fontsize):
     comment_element = json.load(f)
+    # after load acfun comment json file as python list, flatten the list
+    comment_element = [c for sublist in comment_element for c in sublist]
     for i, comment in enumerate(comment_element):
         try:
             p = str(comment['c']).split(',')


### PR DESCRIPTION
As acfun danmaku json file is formatted as '[ [{...}, {...}], [{...}, {...}], [{...}, {...}] ]', it is necessary to flatten the python list loaded from the json file.