### PR TITLE
Fix potential type error when processing Tudou danmaku.

### DIFF
--- a/danmaku2ass.py
+++ b/danmaku2ass.py
@@ -213,10 +213,10 @@ def ReadCommentsTudou2(f, fontsize):
         try:
             c = str(comment['content'])
             prop = json.loads(str(comment['propertis']) or '{}')
-            size = prop.get('size', 1)
+            size = int(prop.get('size', 1))
             assert size in (0, 1, 2)
             size = {0: 0.64, 1: 1, 2: 1.44}[size] * fontsize
-            pos = prop.get('pos', 3)
+            pos = int(prop.get('pos', 3))
             assert pos in (0, 3, 4, 6)
             yield (
                 int(comment['playat'] * 0.001), int(comment['createtime'] * 0.001), i, c,


### PR DESCRIPTION
如 https://github.com/m13253/danmaku2ass/issues/29 里提到，优酷/土豆弹幕的样式以 JSON 字符串放在 `propertis` 里。

之前的处理是取出并解析，从而得到样式的 `dict`。

```python
c = str(comment['content'])
prop = json.loads(str(comment['propertis']) or '{}')
size = prop.get('size', 1)
assert size in (0, 1, 2)
size = {0: 0.64, 1: 1, 2: 1.44}[size] * fontsize
pos = prop.get('pos', 3)
assert pos in (0, 3, 4, 6)
```

在转换土豆的弹幕时没什么问题，但是我在转换优酷的弹幕时发现，有些弹幕 `propertis` 的 JSON，value 都用引号包裹。导致上面的 `size` 和 `pos` 为 `str` 类型，然后在作为 `dict` 下标时出错。

所以在取值同时做一次类型转换。
如有必要我可以附上有问题的弹幕样例。