### PR TITLE
commit from Sky! adapt to new ACFun json format

### DIFF
--- a/danmaku2ass.py
+++ b/danmaku2ass.py
@@ -151,9 +151,11 @@ def ReadCommentsNiconico(f, fontsize):
 
 
 def ReadCommentsAcfun(f, fontsize):
-    comment_element = json.load(f)
+    #comment_element = json.load(f)
     # after load acfun comment json file as python list, flatten the list
-    comment_element = [c for sublist in comment_element for c in sublist]
+    #comment_element = [c for sublist in comment_element for c in sublist]
+    comment_elements = json.load(f)
+    comment_element = comment_elements[2]
     for i, comment in enumerate(comment_element):
         try:
             p = str(comment['c']).split(',')


### PR DESCRIPTION
tweak the ReadCommentsAcfun part to the current acfun danmaku json format
发现的danmaku2ass在现在的A站下下来的json上用不了，发现他们现在json变成了[[],[],[弹幕]]的格式。