### PR TITLE
Force to override symbolic link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install:
 		$(CP) "po/$$locale.mo" "$(DESTDIR)$(PREFIX)/share/locale/$$locale/LC_MESSAGES/danmaku2ass.mo" ; \
 	done
 	$(MKDIR) "$(DESTDIR)$(PREFIX)/bin"
-	$(LN) -s "$(PREFIX)/share/danmaku2ass/danmaku2ass.py" "$(DESTDIR)$(PREFIX)/bin/danmaku2ass"
+	$(LN) -sf "$(PREFIX)/share/danmaku2ass/danmaku2ass.py" "$(DESTDIR)$(PREFIX)/bin/danmaku2ass"
 
 clean:
 	$(RM) -R __pycache__


### PR DESCRIPTION
When reinstalling danmaku2ass on my sysmtem, 

I got this error

```
ln: failed to create symbolic link '/usr/local/bin/danmaku2ass': File exists
make: *** [Makefile:25: install] Error 1
```

Use `ln -sf` fix the problem.