### PR TITLE
Improve ASSEscape using zero-width spaces

### DIFF
--- a/danmaku2ass.py
+++ b/danmaku2ass.py
@@ -677,15 +677,14 @@ def WriteComment(f, c, row, width, height, bottomReserved, fontsize, duration_ma
 
 def ASSEscape(s):
     def ReplaceLeadingSpace(s):
-        sstrip = s.strip(' ')
-        slen = len(s)
-        if slen == len(sstrip):
+        if len(s) == 0:
             return s
-        else:
-            llen = slen - len(s.lstrip(' '))
-            rlen = slen - len(s.rstrip(' '))
-            return ''.join(('\u2007' * llen, sstrip, '\u2007' * rlen))
-    return '\\N'.join((ReplaceLeadingSpace(i) or ' ' for i in str(s).replace('\\', '\\\\').replace('{', '\\{').replace('}', '\\}').split('\n')))
+        if s[0] in (' ', '\t'):
+            s = '\u200b' + s
+        if s[-1] in (' ', '\t'):
+            s = s + '\u200b'
+        return s
+    return '\\N'.join((ReplaceLeadingSpace(i) or ' ' for i in str(s).replace('\\', '\\\u200b').replace('{', '\\{').replace('}', '\\}').split('\n')))
 
 
 def CalculateLength(s):


### PR DESCRIPTION
- A double backslash (```\\```) in ASS displays as two backslashes and does not escape anything. Adding a zero-width space instead fixes this.
![backslashcomp](https://user-images.githubusercontent.com/93988953/202866433-95d8d7d0-184e-4c91-b1ab-bb61f9222d52.png)

- Figure spaces (U+2007) have a different width than regular spaces. Using a zero-width space at the start and end of lines forces correct spacing without changing any characters. Using Hard space ASS tags (```\h```) or no-break spaces (U+00A0) would also work. 
![spacingcomp](https://user-images.githubusercontent.com/93988953/202866438-24d50143-111c-4b58-b055-368735a14048.png)
